### PR TITLE
Fixed wrong use of the base_class variable and removing "Unknown" from the display when the class doesn't have an ascendancy

### DIFF
--- a/main.py
+++ b/main.py
@@ -163,15 +163,16 @@ def determine_location(area_name: str, locations: Dict[str, str]) -> Optional[st
 
 def find_last_level_up(line: str, regex_level: re.Pattern) -> Optional[Dict[str, str]]:
     if match := regex_level.search(line):
-        username, ascension_class, level = match.groups()
-        ascension_class = ascension_class.strip()
+        username, base_class, level = match.groups()
+        base_class = base_class.strip()
         try:
-            if ascension_class in ClassAscendency._value2member_map_:
-                base_class = ClassAscendency(ascension_class).get_class().value
+            if base_class in ClassAscendency._value2member_map_:
+                ascension_class = base_class
+                base_class = ClassAscendency(base_class).get_class().value
             else:
-                base_class = "Unknown"
+                ascension_class = "Unknown"
         except Exception:
-            base_class = "Unknown"
+            ascension_class = "Unknown"
         return {
             "username": username,
             "ascension_class": ascension_class,

--- a/main.py
+++ b/main.py
@@ -236,8 +236,13 @@ def update_rpc(level_info, instance_info=None, status=None):
             status = random_status()
 
     try:
+        details = (
+            f"{level_info['username']} ({level_info['base_class']}"
+            + (f" | {level_info['ascension_class']}" if level_info['ascension_class'] != "Unknown" else "")
+            + f" - Lvl {level_info['level']})"
+        )
         rpc.update(
-            details=f"{level_info['username']} ({level_info['base_class']} | {level_info['ascension_class']} - Lvl {level_info['level']})",
+            details=details,
             state=status,
             start=int(datetime.datetime.now().timestamp()),
             small_image=level_info["ascension_class"].lower(),
@@ -258,8 +263,13 @@ def monitor_log():
 
     last_level_info = get_last_level_up(log_file_path, regex_level)
     if last_level_info:
+        details = (
+            f"{last_level_info['username']} ({last_level_info['base_class']}"
+            + (f" | {last_level_info['ascension_class']}" if last_level_info['ascension_class'] != "Unknown" else "")
+            + f" - Lvl {last_level_info['level']})"
+        )
         rpc.update(
-            details=f"{last_level_info['username']} ({last_level_info['base_class']} | {last_level_info['ascension_class']} - Lvl {last_level_info['level']})",
+            details=details,
             state=random_status(),
             start=int(datetime.datetime.now().timestamp()),
             small_image=last_level_info["ascension_class"].lower(),


### PR DESCRIPTION
On non-ascended characters, instead of showing the following before: ``CharacterName (Unknown | Sorceress - Lvl 2)``
it now shows:  ``CharacterName (Sorceress - Lvl 2)``

On ascended characters: ``CharacterName (Sorceress | Stormweaver - Lvl 25)`` is displayed.

I think that on this case, the Sorceress could be removed (or an option could be added) so it would show:
``CharacterName (Stormweaver - Lvl 25)``
instead. For example, on my character, this is shown:
![image](https://github.com/user-attachments/assets/393fceaf-d43e-4e92-9775-c707dc00a97e)
and because of this, the level is not visible unless mouse is hovered on it.

I tested these changes by manually modifying the log with two of my characters. You can test too to confirm functionality (the files are available on my fork too), before merging in to main.

Other than that, I've transitioned back to Win10 for gaming to fix the loading screen bug with my dualboot setup. Didn't bother committing the simple edits for Linux functionality. Perhaps this could be added someday, especially if there's demand for it.

Also even though when the Client.txt is quite limited, and it doesn't detect swapping characters, we could get around it by player himself writing something in the chat, and this way the status would update on the Discord client. A whitelist of characters should be added tho, by default it would scan the log for level ups and add these characters to the list (I guess Client.txt only reads your level ups, and not the party members either?). This could be saved in a json file in the project root that is created on runtime. Could add this feature within the next few days probably. 

Thanks for this solid Python script! If you want to add me on Discord, my username is @miksuu 

