### PR TITLE
Support official PoE2 client (PathOfExile.exe) alongside Steam build

### DIFF
--- a/main.py
+++ b/main.py
@@ -100,12 +100,15 @@ class ClassAscendency(Enum):
         }[self]
 
 
+PROCESS_CANDIDATES = ["PathOfExileSteam.exe", "PathOfExile.exe"]
+
+
 def find_game_log():
     logging.info("Waiting for the game start..")
     while True:
         try:
             for process in psutil.process_iter(["name", "exe"]):
-                if process.info.get("name") == "PathOfExileSteam.exe":
+                if process.info.get("name") in PROCESS_CANDIDATES:
                     full_path = process.info.get("exe")
                     if full_path:
                         game_dir = os.path.dirname(full_path)


### PR DESCRIPTION
## Summary

`find_game_log()` previously matched only `PathOfExileSteam.exe`, leaving players on the standalone (non-Steam) official PoE2 client without Discord Rich Presence. This PR introduces a `PROCESS_CANDIDATES` list and switches the equality check to membership so both the Steam build and the official client are detected.

## Diff

`+4 / -1` in `main.py`, single hunk:

```python
PROCESS_CANDIDATES = ["PathOfExileSteam.exe", "PathOfExile.exe"]


def find_game_log():
    ...
    for process in psutil.process_iter(["name", "exe"]):
        if process.info.get("name") in PROCESS_CANDIDATES:
            ...
```

No new dependencies, no behavior change for existing Steam users.

## Test plan

- [ ] Existing Steam users keep working: launch with `PathOfExileSteam.exe` running → presence appears (regression evidence in screenshot below — pending live-smoke).
- [ ] Official-client users now work: launch with `PathOfExile.exe` running → presence appears.
- [ ] No process running → loop continues to wait (unchanged).

## Status

Marked **draft** until a Windows live-smoke screenshot is attached to confirm both regression (Steam still works) and the new code path (official client works). Will mark ready as soon as that's in.

## Heads-up

This is the first of a small series of independent PRs against the README "open work" list (owner-pin / AFK status / background tray launcher to follow). Happy to flag intent for the others so you can signal scope appetite before they land — none of them depend on each other.