### PR TITLE
Detect local player & filter party-member level events (auto-pin via 'You have entered')

### DIFF
--- a/main.py
+++ b/main.py
@@ -272,9 +272,22 @@ def update_rpc(level_info, instance_info=None, status=None):
 
 regex_level = re.compile(r": (\w+) \(([\w\s]+)\) is now level (\d+)")
 regex_instance = re.compile(r'Generating level (\d+) area "([^"]+)" with seed (\d+)')
+regex_local_area_entered = re.compile(r": You have entered (.*)\.")
+regex_party_joined = re.compile(r": (\S+) has joined the area\.")
+
+# Owner-detection state machine: filters level events from party members.
+#   UNKNOWN       : no area-entry seen yet -> emit freely
+#   AREA_ENTERED  : ": You have entered ..." just fired, no party member yet -> next level pins
+#   PINNED        : owner identified, only that name's level events update presence
+#   INVALIDATED   : a party member joined inside an unpinned window -> drop until next area entry
+# Override via POE2_CHARACTER_NAME=<ign> short-circuits to PINNED on first area entry.
+_owner_state = "UNKNOWN"
+_pinned_name: Optional[str] = None
+_override_name: Optional[str] = os.environ.get("POE2_CHARACTER_NAME")
 
 
 def monitor_log():
+    global _owner_state, _pinned_name
     game_path = find_game_log()
 
     log_file_path = Path(game_path)
@@ -306,7 +319,32 @@ def monitor_log():
         while True:
             new_lines = log_file.readlines()
             for line in new_lines:
+                if regex_local_area_entered.search(line):
+                    if _override_name is not None:
+                        _owner_state = "PINNED"
+                        _pinned_name = _override_name
+                    else:
+                        _owner_state = "AREA_ENTERED"
+                        _pinned_name = None
+                    continue
+                if party_match := regex_party_joined.search(line):
+                    if _owner_state == "AREA_ENTERED":
+                        _owner_state = "INVALIDATED"
+                    elif _owner_state == "PINNED":
+                        logging.warning(
+                            f"Party member {party_match.group(1)} joined while pinned to {_pinned_name}; keeping pin"
+                        )
+                    continue
+
                 level_info = find_last_level_up(line, regex_level)
+                if level_info:
+                    if _owner_state == "PINNED" and level_info["username"] != _pinned_name:
+                        continue
+                    if _owner_state == "INVALIDATED":
+                        continue
+                    if _owner_state == "AREA_ENTERED":
+                        _owner_state = "PINNED"
+                        _pinned_name = level_info["username"]
                 if level_info and (
                     not current_status["level_info"]
                     or level_info != current_status["level_info"]


### PR DESCRIPTION
## Summary

Adds a small owner-detection state machine so Discord presence stays attached to the local player when other party members are in the same instance. Currently any party member's `: <name> (<class>) is now level <n>` line will overwrite the local player's presence — see README "Detect which player started the script (avoid party-conflict mis-detection)".

How it works:

* Listen for `: You have entered <area>.` (a per-client event — only the local player's `Client.txt` records it) → open a fresh "AREA_ENTERED" window.
* If a `<name> has joined the area.` line fires inside that window → INVALIDATE it (we can't disambiguate the next level event).
* Otherwise, the first `: <name> (<class>) is now level <n>` after `You have entered` belongs to the local player → PIN that name. All subsequent level events for other names are ignored until the next area entry.
* `POE2_CHARACTER_NAME` env var short-circuits the state machine to PINNED on first area entry — useful if you tend to enter zones already in a party.

## Diff

`main.py`: +38 / -0. Two new compiled regexes, three module-level state vars, a few branches at the top of the line-processing loop. No new dependencies, no other files touched. Regexes are taken verbatim from [klayveR/poe-log-monitor `resource/events.json`](https://github.com/klayveR/poe-log-monitor/blob/master/resource/events.json) which has been parsing PoE1 client logs reliably for years (PoE2 inherits the same line format).

## Test plan

- [ ] Solo: enter zone → level up → presence updates with my name (state goes UNKNOWN → AREA_ENTERED → PINNED).
- [ ] In party: enter zone alone → party member joins → party member levels → presence does NOT update (window INVALIDATED).
- [ ] In party with override: `POE2_CHARACTER_NAME=MyName` set → enter zone with party already there → presence updates only on `MyName` level events.
- [ ] Pinned then party joins: party member joining mid-zone after pin keeps the pin and logs a warning (does not overwrite).

## Notes

More features in this series follow (AFK status, background tray launcher) — happy to flag intent so you can signal scope appetite before I open the next one.