### PR TITLE
Reflect AFK/DND status in Rich Presence (small_image + [AFK] suffix)

### DIFF
--- a/main.py
+++ b/main.py
@@ -243,12 +243,21 @@ def rpc_connect():
     return None
 
 
-def update_rpc(level_info, instance_info=None, status=None):
+def update_rpc(
+    level_info,
+    instance_info=None,
+    status=None,
+    small_image_override=None,
+    afk_suffix=False,
+):
     if instance_info:
         status = f"In: {instance_info['location_name']} (Lvl {instance_info['location_level']})"
     else:
         if status is None:
             status = random_status()
+
+    if afk_suffix:
+        status = f"{status} [AFK]"
 
     try:
         details = (
@@ -260,11 +269,15 @@ def update_rpc(level_info, instance_info=None, status=None):
             )
             + f" - Lvl {level_info['level']})"
         )
+        if small_image_override is not None:
+            small_image = small_image_override
+        else:
+            small_image = level_info["ascension_class"].lower().replace(" ", "_")
         rpc.update(
             details=details,
             state=status,
             start=int(datetime.datetime.now().timestamp()),
-            small_image=level_info["ascension_class"].lower().replace(" ", "_"),
+            small_image=small_image,
         )
     except Exception as e:
         logging.error(f"Failed to update RPC: {e}")
@@ -272,6 +285,10 @@ def update_rpc(level_info, instance_info=None, status=None):
 
 regex_level = re.compile(r": (\w+) \(([\w\s]+)\) is now level (\d+)")
 regex_instance = re.compile(r'Generating level (\d+) area "([^"]+)" with seed (\d+)')
+regex_afk = re.compile(r': (DND|AFK) mode is now (?:(ON)\. Autoreply "(.*)"|(OFF))')
+
+_afk_on = False
+_prior_small_image: Optional[str] = None
 
 
 def monitor_log():
@@ -298,6 +315,8 @@ def monitor_log():
             small_image=last_level_info["ascension_class"].lower(),
         )
 
+    global _afk_on, _prior_small_image
+
     with log_file_path.open("r", encoding="utf-8") as log_file:
         log_file.seek(0, 2)
 
@@ -321,6 +340,33 @@ def monitor_log():
                 ):
                     current_status["instance_info"] = instance_info
                     update_rpc(current_status["level_info"], instance_info)
+
+                afk_match = regex_afk.search(line)
+                if afk_match and current_status["level_info"]:
+                    on_token = afk_match.group(2)
+                    if on_token == "ON":
+                        # Snapshot current small_image so OFF restores EXACTLY
+                        # this value, even if level changes during AFK window.
+                        _prior_small_image = (
+                            current_status["level_info"]["ascension_class"]
+                            .lower()
+                            .replace(" ", "_")
+                        )
+                        _afk_on = True
+                        update_rpc(
+                            current_status["level_info"],
+                            current_status["instance_info"],
+                            small_image_override="afk",
+                            afk_suffix=True,
+                        )
+                    else:
+                        _afk_on = False
+                        update_rpc(
+                            current_status["level_info"],
+                            current_status["instance_info"],
+                            small_image_override=_prior_small_image,
+                        )
+                        _prior_small_image = None
 
             time.sleep(5)
 


### PR DESCRIPTION
## Summary

Detect AFK/DND mode toggles from `Client.txt` and reflect them in Discord Rich Presence:

- **AFK ON** → append `[AFK]` to the state string and swap the small image to `afk`.
- **AFK OFF** → restore the *exact* small image that was active when AFK turned on (snapshot survives a level-up that happens inside the AFK window).

Detected log lines:
- `: AFK mode is now ON. Autoreply "..."`
- `: AFK mode is now OFF`
- `: DND mode is now ON. Autoreply "..."`
- `: DND mode is now OFF`

## Diff scope

`+48 / −2` in `main.py`. Two new optional kwargs on `update_rpc` keep every existing call site byte-identical — the only new code path is gated behind a `regex_afk.search(line)` match, so non-AFK lines run through unchanged.

## Asset requirement

Upload an `afk.png` to the Discord developer portal under the application's Rich Presence assets so the `small_image="afk"` lookup resolves. README addendum incoming as a follow-up if helpful.

## Test plan

- [ ] Type `/afk on` in chat → Discord status shows `... [AFK]` and the AFK icon.
- [ ] Level up while AFK → details update, `[AFK]` and AFK icon persist *for the AFK transition*; subsequent level/area pings revert to default behaviour (this PR keeps the diff minimal — full "AFK suffix on every update" can be a follow-up).
- [ ] Type `/afk off` → Discord restores the exact pre-AFK class icon (Witch / Infernalist / etc.).
- [ ] Same for `/dnd on` and `/dnd off`.

## Backport notes

This is a hand-backport of a feature developed in a hexagonal-DDD fork (`src/poe2_rpc/`). The upstream-facing diff is intentionally surgical and stays inside `monitor_log()` + `update_rpc()`.

🤖 Backport prepared with [Claude Code](https://claude.com/claude-code)